### PR TITLE
`--disable_onnxsim`. Suppress the execution of onnxsim on the backend and dare to leave redundant processing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,15 @@ usage:
     [-opam OP_PREFIXES_AFTER_MERGING [OP_PREFIXES_AFTER_MERGING ...]]
     [-of OUTPUT_ONNX_FILE_PATH]
     [-f]
+    [-dos]
     [-n]
 
 optional arguments:
   -h, --help
     show this help message and exit.
 
-  -if INPUT_ONNX_FILE_PATHS [INPUT_ONNX_FILE_PATHS ...], --input_onnx_file_paths INPUT_ONNX_FILE_PATHS [INPUT_ONNX_FILE_PATHS ...]
+  -if INPUT_ONNX_FILE_PATHS [INPUT_ONNX_FILE_PATHS ...], \
+    --input_onnx_file_paths INPUT_ONNX_FILE_PATHS [INPUT_ONNX_FILE_PATHS ...]
       Input onnx file paths. At least two onnx files must be specified.
 
   -sd SRCOP_DESTOP [SRCOP_DESTOP ...], --srcop_destop SRCOP_DESTOP [SRCOP_DESTOP ...]
@@ -66,7 +68,8 @@ optional arguments:
       --srcop_destop model1_src_op1 model2_dest_op1 model1_src_op2 model2_dest_op2 ...
       --srcop_destop combined_model1.2_src_op1 model3_dest_op1 combined_model1.2_src_op2 model3_dest_op2 ...
 
-  -opam OP_PREFIXES_AFTER_MERGING [OP_PREFIXES_AFTER_MERGING ...], --op_prefixes_after_merging OP_PREFIXES_AFTER_MERGING [OP_PREFIXES_AFTER_MERGING ...]
+  -opam OP_PREFIXES_AFTER_MERGING [OP_PREFIXES_AFTER_MERGING ...], \
+    --op_prefixes_after_merging OP_PREFIXES_AFTER_MERGING [OP_PREFIXES_AFTER_MERGING ...]
       Since a single ONNX file cannot contain multiple OPs with the same name,
       a prefix is added to all OPs in each input ONNX model to avoid duplication.
       Specify the same number of paths as input_onnx_file_paths.
@@ -77,6 +80,9 @@ optional arguments:
 
   -f, --output_of_onnx_file_in_the_process_of_fusion
       Output of onnx files in the process of fusion.
+
+  -dos, --disable_onnxsim
+      Suppress the execution of onnxsim on the backend and dare to leave redundant processing.
 
   -n, --non_verbose
       Do not show all information logs. Only error logs are displayed.
@@ -97,6 +103,7 @@ combine(
   onnx_graphs: Union[List[onnx.onnx_ml_pb2.ModelProto], NoneType] = [],
   output_onnx_file_path: Union[str, NoneType] = '',
   output_of_onnx_file_in_the_process_of_fusion: Union[bool, NoneType] = False,
+  disable_onnxsim: Union[bool, NoneType] = False,
   non_verbose: Union[bool, NoneType] = False
 ) -> onnx.onnx_ml_pb2.ModelProto
 
@@ -158,6 +165,10 @@ combine(
 
     output_of_onnx_file_in_the_process_of_fusion: Optional[bool]
         Output of onnx files in the process of fusion.
+        Default: False
+
+    disable_onnxsim: Optional[bool]
+        Suppress the execution of onnxsim on the backend and dare to leave redundant processing.
         Default: False
 
     non_verbose: Optional[bool]

--- a/snc4onnx/__init__.py
+++ b/snc4onnx/__init__.py
@@ -1,3 +1,3 @@
 from snc4onnx.onnx_network_combine import combine, main
 
-__version__ = '1.0.11'
+__version__ = '1.0.12'

--- a/snc4onnx/onnx_network_combine.py
+++ b/snc4onnx/onnx_network_combine.py
@@ -52,6 +52,7 @@ def combine(
     onnx_graphs: Optional[List[onnx.ModelProto]] = [],
     output_onnx_file_path: Optional[str] = '',
     output_of_onnx_file_in_the_process_of_fusion: Optional[bool] = False,
+    disable_onnxsim: Optional[bool] = False,
     non_verbose: Optional[bool] = False,
 ) -> onnx.ModelProto:
     """
@@ -109,6 +110,10 @@ def combine(
 
     output_of_onnx_file_in_the_process_of_fusion: Optional[bool]
         Output of onnx files in the process of fusion.\n\
+        Default: False
+
+    disable_onnxsim: Optional[bool]
+        Suppress the execution of onnxsim on the backend and dare to leave redundant processing.\n\
         Default: False
 
     non_verbose: Optional[bool]
@@ -485,7 +490,7 @@ def combine(
     try:
         # onnx-simplifier does not support optimization of ONNX files containing custom domains,
         # so skip simplify if it contains custom domains
-        if not contains_custom_domain:
+        if not contains_custom_domain and not disable_onnxsim:
             combined_model, check = simplify(combined_model)
     except Exception as e:
         if not non_verbose:
@@ -571,6 +576,12 @@ def main():
         help='Output of onnx files in the process of fusion.'
     )
     parser.add_argument(
+        '-dos',
+        '--disable_onnxsim',
+        action='store_true',
+        help='Suppress the execution of onnxsim on the backend and dare to leave redundant processing.'
+    )
+    parser.add_argument(
         '-n',
         '--non_verbose',
         action='store_true',
@@ -585,6 +596,7 @@ def main():
         input_onnx_file_paths=args.input_onnx_file_paths,
         output_onnx_file_path=args.output_onnx_file_path,
         output_of_onnx_file_in_the_process_of_fusion=args.output_of_onnx_file_in_the_process_of_fusion,
+        disable_onnxsim=args.disable_onnxsim,
         non_verbose=args.non_verbose,
     )
 


### PR DESCRIPTION
- `--disable_onnxsim`
  - Suppress the execution of onnxsim on the backend and dare to leave redundant processing.
- Before - Enabled onnxsim
  ![image](https://github.com/PINTO0309/snc4onnx/assets/33194443/09f73b15-6619-409a-9df6-060e9ead3ef4)
- After - Disabled onnxsim
  ![image](https://github.com/PINTO0309/snc4onnx/assets/33194443/b66628dd-6a97-432f-bad0-bdb66e839486)
